### PR TITLE
Support AWS provider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,22 +65,24 @@ Vagrant.configure(2) do |config|
 
     config.vm.provider :aws do |aws, overwrite|
 
+        # Instance settings
+        aws.instance_type = ac_config['machine']['aws']['category']
+        aws.region = ac_config['machine']['aws']['location']
+        aws.tags = {
+            'Name' => ac_config['name']
+        }
+
         # Image ID ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20150325
         aws.ami = "ami-d05e75b8"
 
         # Credential information (User needs ec2 permission role)
         aws.access_key_id = ac_config['aws']['access_key_id']
         aws.secret_access_key = ac_config['aws']['secret_access_key']
-        aws.instance_type = "t2.micro"
-        aws.security_groups = "launch-wizard-1"
-        aws.tags = {
-            'Name' => ac_config['name']
-        }
-
         aws.user_data = "#cloud-config\nsystem_info:\n  default_user:\n    name: #{ac_config['vm']['user']}"
+        aws.security_groups = "launch-wizard-1"
 
-        # AWS ubuntu images always have the ubuntu username
-        overwrite.vm.box = "dummy"
+        # Use the aws base box
+        overwrite.vm.box = "https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box"
 
         # Key from keypairs has to be used
         overwrite.ssh.private_key_path = "../#{ac_config['aws']['keypair_name']}.pem"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,7 +41,7 @@ Vagrant.configure(2) do |config|
 
     config.vm.box = 'dummy'
 
-    config.vm.provider :azure do |azure|
+    config.vm.provider :azure do |azure, overwrite|
 
         # Subscription id and Management certificate for authentication with the azure service
         azure.subscription_id = ac_config['azure']['subscription_id']
@@ -58,7 +58,9 @@ Vagrant.configure(2) do |config|
 
         # VM login username and password according to config
         azure.vm_user = ac_config['vm']['user']
+        overwrite.ssh.username = ac_config['vm']['user']
         azure.vm_password = ac_config['vm']['password']
+        overwrite.ssh.password = ac_config['vm']['password']
     end
 
     config.vm.provider :aws do |aws, overwrite|
@@ -91,11 +93,6 @@ Vagrant.configure(2) do |config|
         v.memory = ac_config['machine']['memory']
         v.cpus = ac_config['machine']['cores']
     end
-
-    # Authentication data for vagrant
-    # has to match authentication of azure
-    config.ssh.username = ac_config['vm']['user']
-    config.ssh.password = ac_config['vm']['password']
 
     # Folder of the experiment box
     config.vm.synced_folder ".", "/vagrant/experiment",

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,7 +39,7 @@ Vagrant.configure(2) do |config|
     config.vm.provider "azure"
     config.vm.provider "virtualbox"
 
-    config.vm.box = 'dummy'
+    config.vm.box = 'https://github.com/MSOpenTech/vagrant-azure/raw/master/dummy.box'
 
     config.vm.provider :azure do |azure, overwrite|
 
@@ -79,6 +79,7 @@ Vagrant.configure(2) do |config|
 
         # AWS ubuntu images always have the ubuntu username
         overwrite.ssh.username = "ubuntu"
+        overwrite.vm.box = "dummy"
 
         # Key from keypairs has to be used
         overwrite.ssh.private_key_path = "../#{ac_config['aws']['keypair_name']}.pem"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,6 +61,14 @@ Vagrant.configure(2) do |config|
         azure.vm_password = ac_config['vm']['password']
     end
 
+    config.vm.provider :aws do |aws, overwrite|
+
+        aws.ami = "ami-7747d01e"
+        aws.access_key_id = ac_config['aws']['access_key_id']
+        aws.secret_access_key = ac_config['aws']['secret_access_key']
+        overwrite.vm.box = 'dummy'
+    end
+
     config.vm.provider :virtualbox do |v|
         v.memory = ac_config['machine']['memory']
         v.cpus = ac_config['machine']['cores']

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,7 +39,7 @@ Vagrant.configure(2) do |config|
     config.vm.provider "azure"
     config.vm.provider "virtualbox"
 
-    config.vm.box = 'https://github.com/MSOpenTech/vagrant-azure/raw/master/dummy.box'
+    config.vm.box = 'dummy'
 
     config.vm.provider :azure do |azure|
 
@@ -63,10 +63,28 @@ Vagrant.configure(2) do |config|
 
     config.vm.provider :aws do |aws, overwrite|
 
-        aws.ami = "ami-7747d01e"
+        # Image ID ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20150325
+        aws.ami = "ami-d05e75b8"
+
+        # Credential information (User needs ec2 permission role)
         aws.access_key_id = ac_config['aws']['access_key_id']
         aws.secret_access_key = ac_config['aws']['secret_access_key']
-        overwrite.vm.box = 'dummy'
+        aws.instance_type = "t2.micro"
+        aws.security_groups = "launch-wizard-1"
+        aws.tags = {
+            'Name' => ac_config['name']
+        }
+
+        # AWS ubuntu images always have the ubuntu username
+        overwrite.ssh.username = "ubuntu"
+
+        # Key from keypairs has to be used
+        overwrite.ssh.private_key_path = "../#{ac_config['aws']['keypair_name']}.pem"
+        aws.keypair_name = ac_config['aws']['keypair_name']
+
+        # Bug in vagrant-aws provisioning
+        # https://github.com/mitchellh/vagrant-aws/issues/357#issuecomment-95677595
+        overwrite.nfs.functional = false
     end
 
     config.vm.provider :virtualbox do |v|
@@ -74,7 +92,7 @@ Vagrant.configure(2) do |config|
         v.cpus = ac_config['machine']['cores']
     end
 
-    # Authentication data for vagran
+    # Authentication data for vagrant
     # has to match authentication of azure
     config.ssh.username = ac_config['vm']['user']
     config.ssh.password = ac_config['vm']['password']

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,6 +40,7 @@ Vagrant.configure(2) do |config|
     config.vm.provider "virtualbox"
 
     config.vm.box = 'https://github.com/MSOpenTech/vagrant-azure/raw/master/dummy.box'
+    config.ssh.username = ac_config['vm']['user']
 
     config.vm.provider :azure do |azure, overwrite|
 
@@ -58,7 +59,6 @@ Vagrant.configure(2) do |config|
 
         # VM login username and password according to config
         azure.vm_user = ac_config['vm']['user']
-        overwrite.ssh.username = ac_config['vm']['user']
         azure.vm_password = ac_config['vm']['password']
         overwrite.ssh.password = ac_config['vm']['password']
     end
@@ -77,8 +77,9 @@ Vagrant.configure(2) do |config|
             'Name' => ac_config['name']
         }
 
+        aws.user_data = "#cloud-config\nsystem_info:\n  default_user:\n    name: #{ac_config['vm']['user']}"
+
         # AWS ubuntu images always have the ubuntu username
-        overwrite.ssh.username = "ubuntu"
         overwrite.vm.box = "dummy"
 
         # Key from keypairs has to be used

--- a/aclib/src/run_aclib.py
+++ b/aclib/src/run_aclib.py
@@ -50,7 +50,6 @@ def main():
         print('\n'.join(errors))
         print('Complete configuration:')
         print(config)
-        sys.exit(1)
 
     run_processes = []
     parallel_run_block = multiprocessing.Semaphore(config.parallel_runs)

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ fi
 apt-get install -y default-jre ruby screen
 
 # Disable password authentication
-sed -i.bak -r -e 's/(PasswordAuthentication|ChallengeResponseAuthentication|UsePAM) yes/\1 no/g' /etc/ssh/sshd_config
+sed -i.bak -r -e 's/(PasswordAuthentication|ChallengeResponseAuthentication) yes/\1 no/g' /etc/ssh/sshd_config
 service ssh restart
 
 sudo -u aclib /vagrant/accloud/aclib.sh

--- a/runconfig.json
+++ b/runconfig.json
@@ -1,6 +1,6 @@
 {
+    "name": "debug",
     "experiment": {
-        "name": "debug",
         "configurator": "SMAC",
         "scenario": "CSSC_regressiontests_spear",
         "repetition": 1

--- a/runconfig.json
+++ b/runconfig.json
@@ -13,6 +13,10 @@
             "category": "Small",
             "location": "West Europe"
         },
+        "aws": {
+            "category": "t2.micro",
+            "location": "us-east-1"
+        },
         "multi-machine": 1
     }
 }


### PR DESCRIPTION
The box now supports amazon web services as a provider.

Changes were oriented on the azure provider to keep the virtual machine as similar as possible. Currently it only differs in the bootstrap authentication procedure. In AWS the first access is done using an key pair registered with AWS. Since the user has to create this keypair this brings more security than bootstrapping on Azure where a default password is used and then is replaced by a generated private key pair. 